### PR TITLE
Fix error: field 'api_token' doesn't have a default value

### DIFF
--- a/app/Http/Controllers/APIRegisterController.php
+++ b/app/Http/Controllers/APIRegisterController.php
@@ -21,13 +21,15 @@ class APIRegisterController extends Controller
         if ($validator->fails()) {
             return response()->json($validator->errors());
         }
-        User::create([
+        $user = User::create([
             'name' => $request->get('name'),
             'email' => $request->get('email'),
             'password' => bcrypt($request->get('password')),
+            'api_token' => '',
         ]);
-        $user = User::first();
         $token = JWTAuth::fromUser($user);
+        $user->api_token = $token;
+        $user->save();
         
         return Response::json(compact('token'));
     }

--- a/app/User.php
+++ b/app/User.php
@@ -15,7 +15,7 @@ class User extends Authenticatable
      * @var array
      */
     protected $fillable = [
-        'name', 'email', 'password'
+        'name', 'email', 'password', 'api_token'
     ];
 
     /**


### PR DESCRIPTION
Hello!
I have installed your app. When I send POST request to /api/user/register I get error message: SQLSTATE[HY000]: General error: 1364 Field 'api_token' doesn't have a default value.
Please check it. 
UPD: Closed. Should't store the JWT in database.